### PR TITLE
Add benchmark insert and remove edges to stinger

### DIFF
--- a/src/stinger_core.jl
+++ b/src/stinger_core.jl
@@ -1,7 +1,12 @@
 import Base.Libdl: dlopen, dlsym
 import Base: unsafe_convert
 
-export Stinger, remove_edge!, insert_edge!, consistency_check
+export Stinger,
+remove_edge!,
+insert_edge!,
+remove_edges!,
+insert_edges!,
+consistency_check
 
 if "STINGER_LIB_PATH" in keys(ENV)
     stinger_core_lib = dlopen(joinpath(ENV["STINGER_LIB_PATH"],"libstinger_core"))
@@ -103,6 +108,22 @@ function insert_edge!(
         error("Error while adding edge")
     end
     status
+end
+
+function insert_edges!(s::Stinger, edges::AbstractArray, numedges::Integer)
+    m = size(edges,2);
+    numedges <= m || throw(DimensionMismatch("requested to insert too many edges $m < $numedges"))
+    size(edges, 1) == 5 || throw(DimensionMismatch("Wrong input format should be 5×numedges"))
+    for i in 1:numedges
+        insert_edge!(s, edges[1,i], edges[2,i], edges[3,i], edges[4,i], edges[5,i])
+    end
+end
+
+function remove_edges!(s::Stinger, edges::AbstractArray, numedges::Integer)
+    size(edges, 1) == 5 || throw(DimensionMismatch("Input format is 5×numedges (etype, src, dst, weight, times)"))
+    for i in 1:numedges
+        remove_edge!(s, 0, edges[2,i], edges[3,i])
+    end
 end
 
 function consistency_check(s::Stinger, nv::Int64)

--- a/test/add_remove_bench.jl
+++ b/test/add_remove_bench.jl
@@ -8,22 +8,6 @@ function generate!(edges, numvertices::Integer, numedges::Integer)
     end
 end
 
-function insert!(s::Stinger, edges::AbstractArray)
-    numedges = size(edges,2)
-    size(edges, 1) == 5 || error("wrong input format")
-    for i in 1:numedges
-        insert_edge!(s, edges[1,i], edges[2,i], edges[3,i], edges[4,i], edges[5,i])
-    end
-end
-
-function remove!(s::Stinger, edges, numedges)
-    numedges <= size(edges,2) || error("request to delete too many edges")
-    size(edges, 1) == 5 || error("wrong input format")
-    for i in 1:numedges
-        remove_edge!(s, 0, edges[2,i], edges[3,i])
-    end
-end
-
 function bench(numvertices, numedges)
     info("Allocating a STINGER")
     s = Stinger()
@@ -31,19 +15,20 @@ function bench(numvertices, numedges)
     info("Generating the edges")
     @time generate!(edges, numvertices, numedges)
     info("Inserting $(size(edges,2)) edges")
-    @time insert!(s, edges)
+    @time insert_edges!(s, edges, numedges)
     @test consistency_check(s, numvertices) == true
     removals = edges[:,randperm(numedges)]
-    removals = unique(removals,2)
+    removals = unique(removals, 2)
     @show size(removals)
     info("Removing 1/8 of the edges")
-    @time remove!(s, removals, ceil(Int, numedges/8))
+    @time remove_edges!(s, removals, ceil(Int, numedges/8))
     @test consistency_check(s, numvertices) == true
+    return s, edges, removals
 end
 
 info("Setting STINGER Parameters")
 ENV["STINGER_MAX_MEMSIZE"] = 10000000
 info("small run to precompile")
 bench(100, 100)
-info("real becnhmark: nv=1000,ne=4000")
+info("real benchmark: nv=1000,ne=4000")
 bench(1000, 4000)

--- a/test/add_remove_bench.jl
+++ b/test/add_remove_bench.jl
@@ -1,0 +1,49 @@
+using StingerWrapper
+using Base.Test
+
+function generate!(edges, numvertices::Integer, numedges::Integer)
+    for i in 1:numedges
+        src, dst = rand(0:numvertices-1), rand(0:numvertices-1)
+        edges[:,i] = [0, src, dst, 1, 0]
+    end
+end
+
+function insert!(s::Stinger, edges::AbstractArray)
+    numedges = size(edges,2)
+    size(edges, 1) == 5 || error("wrong input format")
+    for i in 1:numedges
+        insert_edge!(s, edges[1,i], edges[2,i], edges[3,i], edges[4,i], edges[5,i])
+    end
+end
+
+function remove!(s::Stinger, edges, numedges)
+    numedges <= size(edges,2) || error("request to delete too many edges")
+    size(edges, 1) == 5 || error("wrong input format")
+    for i in 1:numedges
+        remove_edge!(s, 0, edges[2,i], edges[3,i])
+    end
+end
+
+function bench(numvertices, numedges)
+    info("Allocating a STINGER")
+    s = Stinger()
+    edges = zeros(Int64, 5, numedges)
+    info("Generating the edges")
+    @time generate!(edges, numvertices, numedges)
+    info("Inserting $(size(edges,2)) edges")
+    @time insert!(s, edges)
+    @test consistency_check(s, numvertices) == true
+    removals = edges[:,randperm(numedges)]
+    removals = unique(removals,2)
+    @show size(removals)
+    info("Removing 1/8 of the edges")
+    @time remove!(s, removals, ceil(Int, numedges/8))
+    @test consistency_check(s, numvertices) == true
+end
+
+info("Setting STINGER Parameters")
+ENV["STINGER_MAX_MEMSIZE"] = 10000000
+info("small run to precompile")
+bench(100, 100)
+info("real becnhmark: nv=1000,ne=4000")
+bench(1000, 4000)


### PR DESCRIPTION
I actually got this working. I just Pkg.cloned this repo then followed the directions in the stinger repo to build stinger. Make sure you do the `. ../SOURCEME.sh` part of the Stinger README then start the julia repl.

output of julia test/add_remove_bench.jl looks like:

```
INFO: Setting STINGER Parameters
INFO: small run to precompile
INFO: Allocating a STINGER
stinger[6546]: stinger_new_full 798: Resizing stinger to fit into memory (detected as 10000000)
INFO: Generating the edges
  0.000024 seconds (100 allocations: 10.938 KB)
INFO: Inserting 100 edges
  0.018442 seconds (100 allocations: 1.563 KB)
size(removals) = (5,100)
INFO: Removing 1/8 of the edges
  0.000016 seconds (13 allocations: 208 bytes)
INFO: real becnhmark: nv=1000,ne=4000
INFO: Allocating a STINGER
stinger[6546]: stinger_new_full 798: Resizing stinger to fit into memory (detected as 10000000)
INFO: Generating the edges
  0.000788 seconds (11.39 k allocations: 552.984 KB)
INFO: Inserting 4000 edges
  0.004256 seconds (4.00 k allocations: 62.500 KB)
size(removals) = (5,3989)
INFO: Removing 1/8 of the edges
  0.000368 seconds (500 allocations: 7.813 KB)
```
