### PR TITLE
Add methods to return distances along with parents in bfs

### DIFF
--- a/src/algorithms/bfs.jl
+++ b/src/algorithms/bfs.jl
@@ -1,4 +1,4 @@
-export bfs
+export bfs, bfsdistances
 
 """
 This version is slower as it makes a call to `stinger_max_active_vertex`,
@@ -28,4 +28,40 @@ function bfs(s::Stinger, source::Int64, nv::Int64)
         end
     end
     parents
+end
+
+"""
+This version is slower as it makes a call to `stinger_max_active_vertex`,
+which is sequential and runs through every vertex in the graph. If you know
+the maximum number of active vertices, call `bfsdistances(s, source, nv)` which is faster.
+"""
+function bfsdistances(s::Stinger, source::Int64)
+    nv = get_nv(s)
+    bfsdistances(s, source, nv)
+end
+
+"""
+Obtain both the `parents` array as well as the `distances` from source.
+"""
+function bfsdistances(s::Stinger, source::Int64, nv::Int64)
+    nv>source || throw(DimensionMismatch("Attempting to run BFS with source $source in a graph with only $nv vertices."))
+    parents = fill(-2, nv) #Initialize parents array with -2's.
+    distances = fill(-1, nv)
+    parents[source+1]=-1 #Set source to -1
+    distances[source+1]=0
+    next = Vector{Int64}([source])
+    sizehint!(next, nv)
+    while !isempty(next)
+        src = shift!(next) #Get first element
+        vertexneighbors = getsuccessors(s, src)
+        for vertex in vertexneighbors
+            #If not already set, and is not found in the queue.
+            if parents[vertex+1]==-2
+                push!(next, vertex) #Push onto queue
+                parents[vertex+1] = src
+                distances[vertex+1] = distances[src+1] + 1 #Get the distance
+            end
+        end
+    end
+    parents, distances
 end


### PR DESCRIPTION
@jpfairbanks I added a `bfsdistances` function that returns both the parents and the distances while performing the bfs itself. Should I also add a function that will convert a parents array into a distances array?