### PR TITLE
Parallel BFS

### DIFF
--- a/src/StingerWrapper.jl
+++ b/src/StingerWrapper.jl
@@ -8,6 +8,7 @@ include("fields.jl")
 include("traversal.jl")
 
 include("algorithms/bfs.jl")
+include("algorithms/parallelbfs.jl")
 include("algorithms/kcore.jl")
 include("generators/kronecker.jl")
 

--- a/src/algorithms/parallelbfs.jl
+++ b/src/algorithms/parallelbfs.jl
@@ -1,0 +1,80 @@
+using Base.Threads
+using Base.Threads.Atomic
+import Base: push!, shift!, isempty, getindex
+
+using UnsafeAtomics
+
+export ThreadQueue, LevelSynchronous, bfs
+
+immutable ThreadQueue{T}
+    data::Vector{T}
+    head::Atomic{Int}
+    tail::Atomic{Int}
+end
+
+function ThreadQueue(T::Type, maxlength::Int)
+    q = ThreadQueue(Vector{T}(maxlength), Atomic{Int}(1), Atomic{Int}(1))
+    return q
+end
+
+function push!{T}(q::ThreadQueue{T}, val::T)
+    # TODO: check that head > tail
+    offset = atomic_add!(q.tail, 1)
+    q.data[offset] = val
+    return offset
+end
+
+function shift!{T}(q::ThreadQueue{T})
+    # TODO: check that head < tail
+    offset = atomic_add!(q.head, 1)
+    return q.data[offset]
+end
+
+function isempty(q::ThreadQueue)
+    return ( q.head[] == q.tail[] ) && q.head != 1
+    # return q.head == length(q.data)
+end
+
+function getindex{T}(q::ThreadQueue{T}, iter)
+    return q.data[iter]
+end
+
+abstract BFSAlgorithm
+type LevelSynchronous <: BFSAlgorithm end
+
+function bfskernel(
+        alg::LevelSynchronous, s::Stinger, next::ThreadQueue, parents::Array{Int64},
+        level::Array{Int64}
+    )
+    @threads for src in level
+        foralledges(s, src) do edge, src, etype
+            direction, neighbor = edgeparse(edge)
+            if (direction != 1)
+                parent = UnsafeAtomics.unsafe_atomic_cas!(parents, neighbor+1, -2, src)
+                if parent==-2
+                    push!(next, neighbor) #Push onto queue
+                end
+            end
+        end
+    end
+end
+
+function bfs(alg::LevelSynchronous, s::Stinger, source::Int64, nv::Int64)
+    next = ThreadQueue(Int, nv)
+    parents = fill(-2, nv)
+    bfs(alg, s, next, source, parents)
+end
+
+function bfs(
+        alg::LevelSynchronous, s::Stinger, next::ThreadQueue, source::Int64,
+        parents::Array{Int64}
+    )
+    parents[source+1]=-1 #Set source to -1
+    push!(next, source)
+    while !isempty(next)
+        level = next[next.head[]:next.tail[]-1]
+        next.head[] = next.tail[] #reset the queue
+        bfskernel(alg, s, next, parents, level)
+    end
+    return parents
+end


### PR DESCRIPTION
This uses UnsafeAtomics.jl to implement Level Synchronous BFS in Julia for Stinger.

Initial benchmarks obtained (These are Julia/C numbers):

| Scale/Threads | 1      | 2      | 4       | 8      | 32      | 64     |
|---------------|--------|--------|---------|--------|---------|--------|
| 10            | 1.5859 | 0.0104 | 99.9372 | 0.692  | 1.4707  | 3.5134 |
| 11            | 1.1607 | 0.0217 | 38.5463 | 0.3151 | 1.4657  | 1.8696 |
| 12            | 1.1402 | 0.041  | 0.1108  | 1.3321 | 42.6524 | 1.4289 |
| 13            | 1.0981 | 1.3229 | 1.156   | 1.187  | 19.6739 | 2.2734 |
| 14            | 1.1803 | 0.1913 | 0.1708  | 1.2786 | 11.1331 | 1.3569 |
| 15            | 1.1596 | 0.3282 | 1.2608  | 1.3237 | 1.9055  | 1.5542 |
| 16            | 1.0708 | 0.6158 | 0.4762  | 1.3801 | 1.1388  | 1.5599 |
| 17            | 1.0831 | 1.4996 | 0.766   | 1.4089 | 1.1401  | 1.3816 |
| 18            | 1.0968 | 1.7159 | 1.4202  | 1.4567 | 1.2391  | 1.6354 |
| 19            | 1.1733 | 1.6895 | 1.3711  | 1.6127 | 1.4332  | 1.2869 |
| 20            | 1.1709 | 1.4653 | 1.3411  | 1.4465 | 1.2679  | 1.6138 |

cc: @jpfairbanks @ehein6