### PR TITLE
Install the STINGER dependency using BinDeps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ julia:
 notifications:
   email: false
 # uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("StingerGraphs"); Pkg.test("StingerGraphs"; coverage=true)'
+script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - julia -e 'Pkg.clone(pwd());'
+  - travis_wait 30 julia -e 'Pkg.build("StingerGraphs");'
+  - julia -e 'Pkg.test("StingerGraphs"; coverage=true)'
 after_success:
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("StingerGraphs")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd());'
+  - julia -e 'Pkg.clone("https://github.com/rohitvarkey/UnsafeAtomics.jl"); Pkg.clone(pwd());'
   - travis_wait 30 julia -e 'Pkg.build("StingerGraphs");'
   - julia -e 'Pkg.test("StingerGraphs"; coverage=true)'
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
+sudo: false
 os:
   - linux
   - osx
 julia:
-  - release
+  - 0.6
   - nightly
 notifications:
   email: false
@@ -13,9 +14,5 @@ notifications:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("StingerGraphs"); Pkg.test("StingerGraphs"; coverage=true)'
 after_success:
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("StingerGraphs")); include(joinpath("docs", "make.jl"))'
-# FIXME: Remove once travis actually starts working.
-after_failure:
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("StingerGraphs")); include(joinpath("docs", "make.jl"))'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Documenter
+BinDeps

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,23 @@
+using BinDeps
+
+@BinDeps.setup
+
+libstinger = library_dependency("libstinger")
+
+provides(Sources,
+    URI("https://github.com/rohitvarkey/stinger/archive/stingergraphs.jl_v0.0.1.tar.gz"),
+    libstinger)
+
+stingerbuilddir = joinpath(BinDeps.depsdir(libstinger), "build")
+provides(BuildProcess,
+    (@build_steps begin
+        GetSources(libstinger)
+        CreateDirectory(stingerbuilddir)
+        @build_steps begin
+            ChangeDirectory(stingerbuilddir)
+            `cmake ..`
+            `make`
+        end
+    end), libstinger)
+
+@BinDeps.install Dict(:libstinger => :libstinger)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,22 +2,22 @@ using BinDeps
 
 @BinDeps.setup
 
-libstinger = library_dependency("libstinger")
+libstinger_core = library_dependency("libstinger_core")
 
 provides(Sources,
     URI("https://github.com/rohitvarkey/stinger/archive/stingergraphs.jl_v0.0.1.tar.gz"),
-    libstinger)
+    libstinger_core, unpacked_dir = "stinger-stingergraphs.jl_v0.0.1")
 
-stingerbuilddir = joinpath(BinDeps.depsdir(libstinger), "build")
+stingerbuilddir = joinpath(BinDeps.depsdir(libstinger_core), "src", "stinger-stingergraphs.jl_v0.0.1", "build")
 provides(BuildProcess,
     (@build_steps begin
-        GetSources(libstinger)
+        GetSources(libstinger_core)
         CreateDirectory(stingerbuilddir)
         @build_steps begin
             ChangeDirectory(stingerbuilddir)
             `cmake ..`
             `make`
         end
-    end), libstinger)
+    end), libstinger_core)
 
-@BinDeps.install Dict(:libstinger => :libstinger)
+@BinDeps.install Dict(:libstinger_core => :libstinger_core)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,11 +18,14 @@ provides(BuildProcess,
         CreateDirectory(joinpath(prefix, "lib"))
         @build_steps begin
             ChangeDirectory(stingerbuilddir)
-            FileRule(joinpath(prefix, "lib" , "libstinger_core.dylib"), @build_steps begin
-                `cmake ..`
-                `make`
-                `cp 'lib/libstinger_core.dylib' $prefix/lib/`
-                `cp 'lib/libstinger_alg.dylib' $prefix/lib/`
+            `cmake ..`
+            `make`
+            `ls lib/`
+            FileRule(joinpath(prefix, "lib" , "libstinger_core.$(Base.Libdl.dlext)"), @build_steps begin
+                `cp lib/libstinger_core.$(Base.Libdl.dlext) $prefix/lib/`
+            end)
+            FileRule(joinpath(prefix, "lib" , "libstinger_alg.$(Base.Libdl.dlext)"), @build_steps begin
+                `cp lib/libstinger_alg.$(Base.Libdl.dlext) $prefix/lib/`
             end)
         end
     end), [libstinger_core, libstinger_alg])

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,21 +3,30 @@ using BinDeps
 @BinDeps.setup
 
 libstinger_core = library_dependency("libstinger_core")
+libstinger_alg = library_dependency("libstinger_alg")
 
 provides(Sources,
     URI("https://github.com/rohitvarkey/stinger/archive/stingergraphs.jl_v0.0.1.tar.gz"),
-    libstinger_core, unpacked_dir = "stinger-stingergraphs.jl_v0.0.1")
+    [libstinger_core, libstinger_alg], unpacked_dir = "stinger-stingergraphs.jl_v0.0.1")
 
 stingerbuilddir = joinpath(BinDeps.depsdir(libstinger_core), "src", "stinger-stingergraphs.jl_v0.0.1", "build")
+prefix = joinpath(BinDeps.depsdir(libstinger_core), "usr")
 provides(BuildProcess,
     (@build_steps begin
         GetSources(libstinger_core)
         CreateDirectory(stingerbuilddir)
+        CreateDirectory(joinpath(prefix, "lib"))
         @build_steps begin
             ChangeDirectory(stingerbuilddir)
-            `cmake ..`
-            `make`
+            FileRule(joinpath(prefix, "lib" , "libstinger_core.dylib"), @build_steps begin
+                `cmake ..`
+                `make`
+                `cp 'lib/libstinger_core.dylib' $prefix/lib/`
+                `cp 'lib/libstinger_alg.dylib' $prefix/lib/`
+            end)
         end
-    end), libstinger_core)
+    end), [libstinger_core, libstinger_alg])
 
-@BinDeps.install Dict(:libstinger_core => :libstinger_core)
+@BinDeps.install Dict(
+    :libstinger_core => :libstinger_core,
+    :libstinger_alg => :libstinger_alg)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,9 +18,8 @@ provides(BuildProcess,
         CreateDirectory(joinpath(prefix, "lib"))
         @build_steps begin
             ChangeDirectory(stingerbuilddir)
-            `cmake ..`
+            `cmake .. -DBUILD_TESTING=OFF`
             `make`
-            `ls lib/`
             FileRule(joinpath(prefix, "lib" , "libstinger_core.$(Base.Libdl.dlext)"), @build_steps begin
                 `cp lib/libstinger_core.$(Base.Libdl.dlext) $prefix/lib/`
             end)

--- a/src/stinger_lib.jl
+++ b/src/stinger_lib.jl
@@ -5,6 +5,7 @@ if "STINGER_LIB_PATH" in keys(ENV)
     const stinger_core_lib = dlopen(joinpath(ENV["STINGER_LIB_PATH"],"libstinger_core"))
     const stinger_alg_lib = dlopen(joinpath(ENV["STINGER_LIB_PATH"],"libstinger_alg"))
 else
-    const stinger_core_lib = dlopen("libstinger_core")
-    const stinger_core_alg = dlopen("libstinger_alg")
+    basedir = joinpath(dirname(@__DIR__), "deps", "usr", "lib")
+    const stinger_core_lib = dlopen(joinpath(basedir, "libstinger_core"))
+    const stinger_core_alg = dlopen(joinpath(basedir, "libstinger_alg"))
 end


### PR DESCRIPTION
Heavily based on the Cairo.jl build file. This works locally currently and installs `libstinger_core.dylib` and `libstinger_alg.dylib` in `deps/usr/lib`. This should allow for Travis to finally run our tests!
